### PR TITLE
Cope with '%' in password when waiting for migrations

### DIFF
--- a/astronomer/migration_spinner/command_line.py
+++ b/astronomer/migration_spinner/command_line.py
@@ -17,7 +17,7 @@ def spinner(timeout):
     directory = os.path.join(package_dir, 'migrations')
     config = Config(os.path.join(package_dir, 'alembic.ini'))
     config.set_main_option('script_location', directory)
-    config.set_main_option('sqlalchemy.url', settings.SQL_ALCHEMY_CONN)
+    config.set_main_option('sqlalchemy.url', settings.SQL_ALCHEMY_CONN.replace('%', '%%'))
     script_ = ScriptDirectory.from_config(config)
 
     with settings.engine.connect() as connection:


### PR DESCRIPTION
When there is a '%' in the sql connection url, wait-for-airflow-migrations container complains no permission to connect database.
This commit fix that issue by replacing '%' with '%%'.

cc @ashb 