### PR TITLE
Fix correct directory for publishing artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,11 +93,11 @@ jobs:
           # Even though there is a project field in the JSON credential, gsutil still needs a project set, so lets set pull it from it
           command: |-
             pip-release-utilities/gsutil-auth-helper.sh
-            gsutil -m rsync -a public-read /tmp/workspace/dist/ gs://<< pipeline.parameters.deploy_bucket >>/simple/astronomer-fab-security-manager
+            gsutil -m rsync -a public-read /tmp/workspace/dist/ gs://<< pipeline.parameters.deploy_bucket >>/simple/astronomer-airflow-scripts
       - run:
           name: Rebuild index.html
           command: |-
-            pip-release-utilities/build-index-page.sh "<< pipeline.parameters.deploy_bucket >>" simple/astronomer-fab-security-manager
+            pip-release-utilities/build-index-page.sh "<< pipeline.parameters.deploy_bucket >>" simple/astronomer-airflow-scripts
       - store_artifacts:
           path: /tmp/workspace/dist/
           destination: dist


### PR DESCRIPTION
Artifacts (wheel and tar.gz) were published under `simple/astronomer-fab-security-manager` instead of `simple/astronomer-airflow-scripts`